### PR TITLE
NY

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # BlueSkys
+
+2 line Bronx to NY. 
+
+Attorney General Eric Schneidermann
+
+bs.exempt.sexurities ['NorAmerFedGonMuni','ForeDiplomacy','depositoryInstitution','InsCompBlah','pubUtility','fedCovered','nonProfIssues','coOps','ofEmpBenefitPlans','MMcommPapernBankerAcceptances']
+
+bs.!Not.securities ['lifeIns','FixedAn','forex','collect','commoda','future','perCondo','retInt']
+
+API Search yp.com {'Bronx','depository institutions',function(){return [name,address,phoneNumber], return digital screenshot of GoogleMap location parameters 1 mile square, satelliteView};
+ //input city, input exemption, choose output visual aid presentation
+//return visual aid presentation with a brief description of exempt security's role AS a security, the firms contact phone number and Email
+ 
+
+string OpportunityExemption = "Depository Institution :<"A depositors  institution is a financial institution in the United States (such as a savings bank, commercial bank, savings and loan associations, or credit unions) that is legally allowed to accept monetary deposits from consumers"> , source = "Wikipedia"
+
+string aTWOb= "Bronx to financial district"
+
+<a href="Bronx to financial district : http://www.rome2rio.com/s/The-Bronx/Financial-District-NY-USA">theTwoLine</a>


### PR DESCRIPTION
Two Line from Bronx to Financial District

Hyperlink routes, current location to target firm, output visual aid and provide a brief description.
